### PR TITLE
feat: Add Gaussian Process Regression preprocessing option

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -42,6 +42,8 @@ def main():
                         help='Random seed for reproducibility')
     parser.add_argument('--augment_data', action='store_true',
                         help='Enable data augmentation for training data (11 rotations, 30 deg increments)')
+    parser.add_argument('--apply_gpr', action='store_true',
+                        help='Apply Gaussian Process Regression to the input signals during preprocessing.')
     
     args = parser.parse_args()
     
@@ -81,7 +83,8 @@ def main():
         print("="*50)
         X_train, X_val, X_test, y_train, y_val, y_test, snr_train, snr_val, snr_test, mods = prepare_data_by_snr(
             dataset, 
-            augment_data=args.augment_data
+            augment_data=args.augment_data,
+            apply_gpr=args.apply_gpr
         )
     
     # Training


### PR DESCRIPTION
This commit introduces a new data preprocessing method using Gaussian Process Regression (GPR) for radio signal data.

Key changes:
- Added GPR functions (`calculate_power`, `estimate_noise_std`, `apply_gp_regression`) to `src/preprocess.py`.
- Modified `prepare_data_by_snr` in `src/preprocess.py` to include an `apply_gpr` boolean flag. If true, GPR is applied to each signal sample, adjusting for its SNR.
- Added a command-line argument `--apply_gpr` to `src/main.py` to control the GPR preprocessing step.

New Dependencies:
- scikit-learn
- scipy

Testing Note:
The GPR code integration has been completed as per my plan. However, runtime testing was blocked by an issue with loading the `RML2016.10a_dict.pkl` dataset. The error "invalid load key, 'v'" occurred consistently, both with and without GPR enabled, suggesting a corrupted dataset file. Therefore, the full runtime behavior and impact of GPR preprocessing could not be verified in the current environment.