### PR TITLE
I'm working on refactoring your Keras imports to use `keras` instead …

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,53 @@ The repository includes implementations of various models for radio modulation c
 - Complex NN: Neural network with complex-valued operations
 - ResNet: Residual network architecture
 - Transformer: Attention-based transformer model
+
+## Usage
+
+To run the project, use `src/main.py`. Key command-line arguments include:
+
+*   `--mode`: Mode of operation. Choices: `explore`, `train`, `evaluate`, `all`. Default: `all`.
+*   `--model_type`: Model architecture to use. Choices: `cnn1d`, `cnn2d`, `resnet`, `complex_nn`, `transformer`, `all`. Default: `resnet`.
+*   `--dataset_path`: Path to the RadioML dataset. Default: `../RML2016.10a_dict.pkl`.
+*   `--epochs`: Number of training epochs. Default: 400.
+*   `--batch_size`: Batch size for training. Default: 128.
+*   `--augment_data`: Enable data augmentation.
+*   `--denoising_method`: Denoising method to apply to the input signals. Default: `gpr`.
+    *   `gpr`: Gaussian Process Regression. (Default kernel is RBF; Matern and RationalQuadratic also available).
+    *   `wavelet`: Wavelet-based denoising.
+    *   `ddae`: Deep Denoising Autoencoder. Uses a pre-trained model. See below for training your own DDAE.
+    *   `none`: No denoising is applied.
+*   `--ddae_model_path`: Path to the trained Denoising Autoencoder model. Default: `model_weight_saved/ddae_model.keras`.
+
+Example:
+```bash
+python src/main.py --model_type resnet --denoising_method wavelet --epochs 50
+```
+
+### Training the Denoising Autoencoder
+
+The Deep Denoising Autoencoder (DDAE) model can be (re)trained using the `src/train_autoencoder.py` script. This script trains the DAE on signals from the dataset, where high-SNR signals are treated as clean targets and noise is added to create noisy inputs.
+
+Key arguments for `src/train_autoencoder.py`:
+
+*   `--dataset_path`: Path to the RadioML dataset (default: `../RML2016.10a_dict.pkl`, assumes script is run from `src/`).
+*   `--epochs`: Number of training epochs (default: 100).
+*   `--batch_size`: Batch size for training (default: 256).
+*   `--learning_rate`: Learning rate for the optimizer (default: 1e-3).
+*   `--high_snr_threshold`: SNR value (dB) above which signals are considered "clean" targets (default: 10).
+*   `--noisy_snr_target`: Target SNR (dB) for the noisy signals generated for training (default: 0).
+*   `--output_model_dir`: Directory to save the trained model weights (default: `../model_weight_saved/`).
+*   `--output_model_name`: Filename for the saved model (default: `ddae_model.keras`).
+
+Example training command (assuming you are in the `src` directory):
+
+```bash
+python train_autoencoder.py --dataset_path ../RML2016.10a_dict.pkl --epochs 50 --output_model_name ddae_custom_model.keras
+```
+
+Alternatively, if running from the project root:
+```bash
+python src/train_autoencoder.py --dataset_path RML2016.10a_dict.pkl --epochs 50 --output_model_name ddae_custom_model.keras --output_model_dir model_weight_saved/
+```
+
+The trained model can then be used with `src/main.py` by specifying the `--denoising_method ddae` and, if using a custom name/path, the `--ddae_model_path` argument (e.g., `--ddae_model_path model_weight_saved/ddae_custom_model.keras` if run from project root).

--- a/src/main.py
+++ b/src/main.py
@@ -42,8 +42,11 @@ def main():
                         help='Random seed for reproducibility')
     parser.add_argument('--augment_data', action='store_true',
                         help='Enable data augmentation for training data (11 rotations, 30 deg increments)')
-    parser.add_argument('--apply_gpr', action='store_true',
-                        help='Apply Gaussian Process Regression to the input signals during preprocessing.')
+    parser.add_argument('--denoising_method', type=str, default='gpr',
+                        choices=['gpr', 'wavelet', 'ddae', 'none'],
+                        help='Denoising method to apply to the signals (gpr, wavelet, ddae, none)')
+    parser.add_argument('--ddae_model_path', type=str, default='model_weight_saved/ddae_model.keras',
+                        help='Path to the trained Denoising Autoencoder model (.keras file). Assumes path from project root.')
     
     args = parser.parse_args()
     
@@ -84,7 +87,8 @@ def main():
         X_train, X_val, X_test, y_train, y_val, y_test, snr_train, snr_val, snr_test, mods = prepare_data_by_snr(
             dataset, 
             augment_data=args.augment_data,
-            apply_gpr=args.apply_gpr
+            denoising_method=args.denoising_method,
+            ddae_model_path=args.ddae_model_path
         )
     
     # Training

--- a/src/model/autoencoder_model.py
+++ b/src/model/autoencoder_model.py
@@ -1,0 +1,120 @@
+from keras.layers import Input, Conv1D, MaxPooling1D, UpSampling1D, BatchNormalization, Activation
+from keras.models import Model, load_model
+from keras.optimizers import Adam
+
+def build_dae_model(input_shape):
+    """
+    Builds a Denoising Autoencoder (DAE) model.
+    Args:
+        input_shape (tuple): Shape of the input data (sequence_length, num_channels).
+    Returns:
+        keras.models.Model: The constructed DAE model.
+    """
+    inputs = Input(shape=input_shape)
+
+    # Encoder
+    # Block 1
+    x = Conv1D(filters=64, kernel_size=7, padding='same')(inputs)
+    x = BatchNormalization()(x)
+    x = Activation('relu')(x)
+    x = MaxPooling1D(pool_size=2)(x)  # 128 -> 64
+
+    # Block 2
+    x = Conv1D(filters=32, kernel_size=7, padding='same')(x)
+    x = BatchNormalization()(x)
+    x = Activation('relu')(x)
+    x = MaxPooling1D(pool_size=2)(x)  # 64 -> 32
+
+    # Bottleneck (Encoded representation)
+    encoded = Conv1D(filters=16, kernel_size=7, padding='same', activation='relu')(x)
+    # No max pooling here, this is the bottleneck
+
+    # Decoder
+    # Block 1
+    x = Conv1D(filters=32, kernel_size=7, padding='same')(encoded)
+    x = BatchNormalization()(x)
+    x = Activation('relu')(x)
+    x = UpSampling1D(size=2)(x)  # 32 -> 64
+
+    # Block 2
+    x = Conv1D(filters=64, kernel_size=7, padding='same')(x)
+    x = BatchNormalization()(x)
+    x = Activation('relu')(x)
+    x = UpSampling1D(size=2)(x)  # 64 -> 128
+    
+    # Output layer
+    # Reconstruct the original number of channels (e.g., 2 for I/Q)
+    # Using 'linear' activation for reconstruction, as signal values can be positive or negative.
+    # 'tanh' could also be an option if inputs are normalized to [-1, 1].
+    decoded = Conv1D(filters=input_shape[-1], kernel_size=7, activation='linear', padding='same')(x)
+
+    autoencoder = Model(inputs, decoded)
+    return autoencoder
+
+def compile_dae_model(model, learning_rate=1e-3):
+    """
+    Compiles the DAE model.
+    Args:
+        model (keras.models.Model): The DAE model to compile.
+        learning_rate (float): Learning rate for the Adam optimizer.
+    """
+    optimizer = Adam(learning_rate=learning_rate)
+    model.compile(optimizer=optimizer, loss='mean_squared_error')
+
+def save_dae_model(model, filepath):
+    """
+    Saves the DAE model to a file.
+    Args:
+        model (keras.models.Model): The DAE model to save.
+        filepath (str): Path to save the model file.
+    """
+    model.save(filepath)
+    print(f"Model saved to {filepath}")
+
+def load_dae_model(filepath):
+    """
+    Loads a DAE model from a file.
+    Args:
+        filepath (str): Path to the model file.
+    Returns:
+        keras.models.Model: The loaded DAE model.
+    """
+    print(f"Loading model from {filepath}...")
+    # No custom objects needed for these standard layers
+    model = load_model(filepath)
+    print("Model loaded successfully.")
+    return model
+
+if __name__ == '__main__':
+    # Example Usage
+    seq_len = 128
+    num_chan = 2  # For I and Q components
+    shape = (seq_len, num_chan)
+    
+    print("Building DAE model...")
+    dae = build_dae_model(input_shape=shape)
+    
+    print("\nCompiling DAE model...")
+    compile_dae_model(dae, learning_rate=0.001)
+    
+    print("\nDAE Model Summary:")
+    dae.summary()
+    
+    # Test save and load
+    import tempfile
+    import os
+
+    # Create a temporary directory to ensure the file can be written
+    with tempfile.TemporaryDirectory() as tmpdir:
+        temp_model_path = os.path.join(tmpdir, "temp_dae_model.keras")
+        
+        print(f"\nSaving model to temporary file: {temp_model_path}")
+        save_dae_model(dae, temp_model_path)
+        
+        print("\nLoading model from temporary file...")
+        loaded_dae = load_dae_model(temp_model_path)
+        
+        print("\nLoaded DAE Model Summary:")
+        loaded_dae.summary()
+
+    print("\nAutoencoder model functions created and tested successfully.")

--- a/src/model/cnn1d_model.py
+++ b/src/model/cnn1d_model.py
@@ -1,4 +1,3 @@
-import tensorflow as tf
 from keras.models import Sequential
 from keras.layers import Dense, Dropout, Flatten
 from keras.layers import Conv1D, MaxPooling1D

--- a/src/model/cnn2d_model.py
+++ b/src/model/cnn2d_model.py
@@ -1,4 +1,3 @@
-import tensorflow as tf
 from keras.models import Sequential
 from keras.layers import Dense, Dropout, Flatten
 from keras.layers import Conv2D, MaxPooling2D

--- a/src/train_autoencoder.py
+++ b/src/train_autoencoder.py
@@ -1,0 +1,213 @@
+import argparse
+import os
+import numpy as np
+import pickle
+import tensorflow as tf
+import keras # Added for keras.utils.set_random_seed
+from sklearn.model_selection import train_test_split
+from keras.callbacks import EarlyStopping, ModelCheckpoint # Changed from tensorflow.keras.callbacks
+
+# Add src directory to Python path to allow direct import of modules
+# This might be needed if running the script directly and src is not in PYTHONPATH
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from model.autoencoder_model import build_dae_model, compile_dae_model, save_dae_model
+
+def set_random_seed(seed=42):
+    """Sets random seeds for reproducibility."""
+    np.random.seed(seed)
+    tf.random.set_seed(seed) # Retained as per instruction for backend seeding
+    # For Keras specific random operations if any
+    keras.utils.set_random_seed(seed) # Changed from tf.keras.utils
+    os.environ['PYTHONHASHSEED'] = str(seed)
+    print(f"Random seed set to {seed}")
+
+def add_noise_to_signals(signals, target_snr_db):
+    """
+    Adds Gaussian noise to signals to achieve a target SNR.
+    Args:
+        signals (np.ndarray): Array of clean signals (num_samples, sequence_length, num_channels).
+        target_snr_db (float): Target Signal-to-Noise Ratio in dB.
+    Returns:
+        np.ndarray: Array of noisy signals.
+    """
+    noisy_signals_list = []
+    for i in range(signals.shape[0]):
+        signal_sample = signals[i] # Shape (sequence_length, num_channels)
+        
+        if signal_sample.shape[1] != 2:
+            raise ValueError(f"Expected signal_sample to have 2 channels (I and Q), but got {signal_sample.shape[1]}")
+
+        I = signal_sample[:, 0]
+        Q = signal_sample[:, 1]
+        complex_signal = I + 1j * Q
+        
+        sig_power = np.mean(np.abs(complex_signal)**2)
+        if sig_power == 0: # Handle zero-power signals to avoid division by zero
+            # If signal power is zero, noise power also becomes undefined or zero depending on interpretation.
+            # Adding zero noise or very small noise.
+            noise_std = 1e-9 
+        else:
+            snr_linear = 10**(target_snr_db / 10)
+            noise_power = sig_power / snr_linear
+            noise_std = np.sqrt(noise_power / 2) # Divide by 2 for I and Q components
+
+        noise_i = np.random.normal(0, noise_std, size=I.shape)
+        noise_q = np.random.normal(0, noise_std, size=Q.shape)
+        
+        noisy_I = I + noise_i
+        noisy_Q = Q + noise_q
+        
+        noisy_signal_channels = np.stack((noisy_I, noisy_Q), axis=-1)
+        noisy_signals_list.append(noisy_signal_channels)
+        
+    return np.array(noisy_signals_list)
+
+def load_and_prepare_data(dataset_path, high_snr_threshold=10, noisy_snr_target=0, val_split=0.2):
+    """
+    Loads data, selects high SNR signals as clean, generates noisy versions,
+    normalizes, and splits into training/validation sets.
+    Args:
+        dataset_path (str): Path to the RadioML dataset.
+        high_snr_threshold (int): Minimum SNR to consider a signal "clean".
+        noisy_snr_target (int): Target SNR for the noisy signals.
+        val_split (float): Proportion of data for validation set.
+    Returns:
+        tuple: (X_noisy_train, X_noisy_val, X_clean_train, X_clean_val)
+    """
+    print(f"Loading dataset from: {dataset_path}")
+    with open(dataset_path, 'rb') as f:
+        dataset = pickle.load(f, encoding='latin1')
+    
+    clean_signals_list = []
+    print(f"Extracting clean signals with SNR >= {high_snr_threshold} dB...")
+    for (mod, snr), data_samples in dataset.items():
+        if snr >= high_snr_threshold:
+            # Original shape is (N, 2, 128) -> I/Q components first
+            # Transpose to (N, 128, 2) -> sequence_length, num_channels (I/Q)
+            samples_transposed = np.transpose(data_samples, (0, 2, 1))
+            clean_signals_list.append(samples_transposed)
+    
+    if not clean_signals_list:
+        raise ValueError(f"No signals found with SNR >= {high_snr_threshold}. Check dataset or threshold.")
+        
+    X_clean = np.vstack(clean_signals_list)
+    print(f"Total clean signals extracted: {X_clean.shape[0]}")
+    
+    print(f"Generating noisy signals with target SNR: {noisy_snr_target} dB...")
+    X_noisy = add_noise_to_signals(X_clean, noisy_snr_target)
+    
+    print("Normalizing signals...")
+    # Global normalization based on the absolute maximum value in both noisy and clean sets
+    # This ensures that both input (noisy) and target (clean) are scaled consistently.
+    # Important for autoencoders where output should match the scale of the target.
+    temp_for_norm = np.vstack((X_noisy.reshape(-1, X_noisy.shape[-1]), 
+                               X_clean.reshape(-1, X_clean.shape[-1])))
+    max_val = np.max(np.abs(temp_for_norm))
+    
+    if max_val == 0:
+        print("Warning: Max value for normalization is 0. Skipping normalization.")
+    else:
+        X_noisy = X_noisy / max_val
+        X_clean = X_clean / max_val
+        print(f"Signals normalized by global max value: {max_val:.4f}")
+
+    print("Splitting data into training and validation sets...")
+    X_noisy_train, X_noisy_val, X_clean_train, X_clean_val = train_test_split(
+        X_noisy, X_clean, test_size=val_split, random_state=42
+    )
+    print(f"Training set: Noisy={X_noisy_train.shape}, Clean={X_clean_train.shape}")
+    print(f"Validation set: Noisy={X_noisy_val.shape}, Clean={X_clean_val.shape}")
+    
+    return X_noisy_train, X_noisy_val, X_clean_train, X_clean_val
+
+def main():
+    parser = argparse.ArgumentParser(description='Train Denoising Autoencoder (DAE) for RadioML signals.')
+    parser.add_argument('--dataset_path', type=str, default='../RML2016.10a_dict.pkl',
+                        help='Path to the RadioML dataset file.')
+    parser.add_argument('--epochs', type=int, default=100,
+                        help='Number of training epochs.')
+    parser.add_argument('--batch_size', type=int, default=256,
+                        help='Batch size for training.')
+    parser.add_argument('--learning_rate', type=float, default=1e-3,
+                        help='Learning rate for the optimizer.')
+    parser.add_argument('--high_snr_threshold', type=int, default=10,
+                        help='Minimum SNR (dB) to consider signals as clean.')
+    parser.add_argument('--noisy_snr_target', type=int, default=0,
+                        help='Target SNR (dB) for generating noisy signals.')
+    parser.add_argument('--output_model_dir', type=str, default='../model_weight_saved/',
+                        help='Directory to save the trained DAE model.')
+    parser.add_argument('--output_model_name', type=str, default='ddae_model.keras',
+                        help='Filename for the saved DAE model.')
+    parser.add_argument('--input_seq_length', type=int, default=128,
+                        help='Sequence length of the input signals.')
+    parser.add_argument('--num_channels', type=int, default=2,
+                        help='Number of channels in the input signals (e.g., 2 for I/Q).')
+    parser.add_argument('--random_seed', type=int, default=42,
+                        help='Random seed for reproducibility.')
+    
+    args = parser.parse_args()
+
+    set_random_seed(args.random_seed)
+
+    os.makedirs(args.output_model_dir, exist_ok=True)
+    output_model_path = os.path.join(args.output_model_dir, args.output_model_name)
+
+    # Load and prepare data
+    try:
+        X_noisy_train, X_noisy_val, X_clean_train, X_clean_val = load_and_prepare_data(
+            args.dataset_path,
+            args.high_snr_threshold,
+            args.noisy_snr_target
+        )
+    except FileNotFoundError:
+        print(f"Error: Dataset file not found at {args.dataset_path}")
+        print("Please ensure the path is correct. If running from src/, it might be '../RML2016.10a_dict.pkl'")
+        return
+    except ValueError as e:
+        print(f"Error during data preparation: {e}")
+        return
+
+    # Build and compile model
+    input_shape = (args.input_seq_length, args.num_channels)
+    dae_model = build_dae_model(input_shape)
+    compile_dae_model(dae_model, args.learning_rate)
+    
+    print("\nDAE Model Summary:")
+    dae_model.summary()
+
+    # Define callbacks
+    early_stopping = EarlyStopping(
+        monitor='val_loss', 
+        patience=15, 
+        restore_best_weights=True, 
+        verbose=1
+    )
+    model_checkpoint = ModelCheckpoint(
+        filepath=output_model_path, 
+        monitor='val_loss', 
+        save_best_only=True, 
+        verbose=1
+    )
+
+    # Train model
+    print("\nStarting DAE model training...")
+    history = dae_model.fit(
+        X_noisy_train, X_clean_train,
+        validation_data=(X_noisy_val, X_clean_val),
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        callbacks=[early_stopping, model_checkpoint]
+    )
+    print("Training complete.")
+    print(f"Best model saved at {output_model_path} by ModelCheckpoint.")
+
+    # Optionally save the final model explicitly if ModelCheckpoint might not be the last epoch
+    # For example, if training finishes by epochs rather than early stopping.
+    final_model_path = os.path.join(args.output_model_dir, args.output_model_name.replace('.keras', '_final.keras'))
+    save_dae_model(dae_model, final_model_path)
+    print(f"Final model state (after all epochs or early stopping) saved to {final_model_path}")
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,0 +1,211 @@
+import unittest
+import numpy as np
+import sys
+import os
+import tempfile
+from tensorflow.keras.models import Sequential, Model # Added Model
+from tensorflow.keras.layers import Input, Conv1D, Dense # Added Dense
+from tensorflow.keras.optimizers import SGD # Added SGD
+
+# Add src directory to Python path to allow direct import of modules
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src.preprocess import apply_gp_regression, apply_wavelet_denoising, apply_ddae_denoising
+# RBF, Matern, RationalQuadratic are used internally by apply_gp_regression,
+# so direct import for testing them separately is not strictly needed here
+# unless we want to test kernel objects themselves.
+# Attempting to import build_dae_model and compile_dae_model for the dummy model
+try:
+    from src.model.autoencoder_model import build_dae_model, compile_dae_model
+    dae_builder_available = True
+except ImportError:
+    dae_builder_available = False
+    print("Warning: src.model.autoencoder_model components not found. DDAE functional test will use a simpler dummy model.")
+
+
+class TestDenoisingMethods(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up for all tests in the class."""
+        # Create a dummy DAE model once for all DDAE tests
+        cls.temp_dir = tempfile.TemporaryDirectory()
+        cls.dummy_model_path = os.path.join(cls.temp_dir.name, "dummy_dae_model.keras")
+        
+        if dae_builder_available:
+            print("Using build_dae_model for dummy DAE model in tests.")
+            # Use the actual DAE builder if available for more realistic structure
+            dummy_model = build_dae_model(input_shape=(128, 2))
+            compile_dae_model(dummy_model, learning_rate=0.01) # Compile with a basic optimizer
+        else:
+            print("Using simple Sequential model for dummy DAE model in tests.")
+            # Fallback to a very simple model if the main DAE builder is not found
+            dummy_model = Sequential([
+                Input(shape=(128, 2)),
+                Conv1D(filters=4, kernel_size=3, activation='relu', padding='same'), # Minimal processing
+                Conv1D(filters=2, kernel_size=3, activation='linear', padding='same') # Output 2 channels
+            ])
+            dummy_model.compile(optimizer=SGD(learning_rate=0.01), loss='mse')
+
+        # "Train" for one epoch on random data
+        # For DDAE, input and output are typically the same for training a simple autoencoder
+        # or input is noisy and output is clean for a denoising autoencoder.
+        # For this dummy test, we just need it to be able to predict.
+        dummy_data_x = np.random.rand(10, 128, 2)
+        dummy_data_y = np.random.rand(10, 128, 2) # Or use dummy_data_x if it's a simple AE
+        dummy_model.fit(dummy_data_x, dummy_data_y, epochs=1, verbose=0)
+        dummy_model.save(cls.dummy_model_path)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up after all tests in the class."""
+        cls.temp_dir.cleanup()
+
+    def setUp(self):
+        """Set up common test data."""
+        np.random.seed(42) # for reproducibility
+        self.sample_signal_length = 128
+        self.sample_signal = np.random.rand(self.sample_signal_length) + 1j * np.random.rand(self.sample_signal_length)
+        self.noise_std = 0.1
+
+    def test_gp_regression_rbf(self):
+        """Test GPR with RBF kernel."""
+        denoised_signal = apply_gp_regression(
+            self.sample_signal,
+            self.noise_std,
+            kernel_name='rbf',
+            length_scale=1.0
+        )
+        self.assertIsInstance(denoised_signal, np.ndarray)
+        self.assertEqual(denoised_signal.shape, self.sample_signal.shape)
+        self.assertTrue(np.iscomplexobj(denoised_signal))
+
+    def test_gp_regression_matern(self):
+        """Test GPR with Matern kernel."""
+        denoised_signal = apply_gp_regression(
+            self.sample_signal,
+            self.noise_std,
+            kernel_name='matern',
+            length_scale=1.0,
+            matern_nu=1.5
+        )
+        self.assertIsInstance(denoised_signal, np.ndarray)
+        self.assertEqual(denoised_signal.shape, self.sample_signal.shape)
+        self.assertTrue(np.iscomplexobj(denoised_signal))
+
+    def test_gp_regression_rational_quadratic(self):
+        """Test GPR with RationalQuadratic kernel."""
+        denoised_signal = apply_gp_regression(
+            self.sample_signal,
+            self.noise_std,
+            kernel_name='rational_quadratic',
+            length_scale=1.0,
+            rational_quadratic_alpha=1.0
+        )
+        self.assertIsInstance(denoised_signal, np.ndarray)
+        self.assertEqual(denoised_signal.shape, self.sample_signal.shape)
+        self.assertTrue(np.iscomplexobj(denoised_signal))
+
+    def test_gp_regression_unknown_kernel(self):
+        """Test GPR with an unknown kernel, expecting fallback to RBF."""
+        # This test assumes that a warning is printed and RBF is used.
+        # We can't directly test the print output without more complex mocking,
+        # but we can ensure it still runs and produces valid output.
+        denoised_signal = apply_gp_regression(
+            self.sample_signal,
+            self.noise_std,
+            kernel_name='unknown_kernel_test',
+            length_scale=1.0
+        )
+        self.assertIsInstance(denoised_signal, np.ndarray)
+        self.assertEqual(denoised_signal.shape, self.sample_signal.shape)
+        self.assertTrue(np.iscomplexobj(denoised_signal))
+
+
+    def test_wavelet_denoising(self):
+        """Test Wavelet Denoising with default parameters."""
+        denoised_signal = apply_wavelet_denoising(self.sample_signal)
+        self.assertIsInstance(denoised_signal, np.ndarray)
+        self.assertEqual(denoised_signal.shape, self.sample_signal.shape)
+        self.assertTrue(np.iscomplexobj(denoised_signal))
+        # Check that the output is not the same as input (i.e., some denoising occurred)
+        # This might not always be true if the signal is pure noise and thresholding removes everything
+        # or if the signal is perfectly clean. Given random input, it should differ.
+        self.assertFalse(np.array_equal(denoised_signal, self.sample_signal), "Wavelet denoising did not alter the signal.")
+
+
+    def test_wavelet_denoising_params(self):
+        """Test Wavelet Denoising with specific parameters."""
+        denoised_signal = apply_wavelet_denoising(
+            self.sample_signal,
+            wavelet='db1', # Daubechies 1 (Haar)
+            level=2,
+            mode='hard'
+        )
+        self.assertIsInstance(denoised_signal, np.ndarray)
+        self.assertEqual(denoised_signal.shape, self.sample_signal.shape)
+        self.assertTrue(np.iscomplexobj(denoised_signal))
+        self.assertFalse(np.array_equal(denoised_signal, self.sample_signal), "Wavelet denoising (db1, level 2, hard) did not alter the signal.")
+
+
+    def test_ddae_denoising_placeholder(self):
+        """Test the DDAE Denoising placeholder function."""
+        # Since it's a placeholder, it should return the original signal.
+        # We can also capture stdout to check the message, but that's optional.
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            denoised_signal = apply_ddae_denoising(self.sample_signal)
+        
+        # Check console output
+        self.assertIn("DDAE denoising is not yet implemented.", f.getvalue())
+
+        # Check that the output is identical to the input
+        self.assertIsInstance(denoised_signal, np.ndarray)
+        self.assertEqual(denoised_signal.shape, self.sample_signal.shape)
+        self.assertTrue(np.iscomplexobj(denoised_signal))
+        self.assertTrue(np.array_equal(denoised_signal, self.sample_signal), "DDAE placeholder did not return the original signal.")
+
+    def test_ddae_denoising_functional(self):
+        """Test the DDAE Denoising function with a dummy model."""
+        # Test Case 1: Model Not Found
+        invalid_path = "non_existent_dummy_model.keras"
+        # Ensure the invalid path truly doesn't exist for a clean test
+        if os.path.exists(invalid_path):
+            os.remove(invalid_path) 
+
+        denoised_signal_no_model = apply_ddae_denoising(self.sample_signal, model_path=invalid_path)
+        self.assertTrue(
+            np.array_equal(denoised_signal_no_model, self.sample_signal),
+            "DDAE should return original signal if model is not found."
+        )
+
+        # Test Case 2: Functional Denoising with Dummy Model
+        # The dummy_model_path is created in setUpClass
+        denoised_signal_functional = apply_ddae_denoising(self.sample_signal, model_path=self.dummy_model_path)
+        
+        self.assertIsInstance(denoised_signal_functional, np.ndarray)
+        self.assertEqual(denoised_signal_functional.shape, self.sample_signal.shape)
+        self.assertTrue(np.iscomplexobj(denoised_signal_functional))
+        
+        # Check if the signal was altered by the dummy model's processing
+        # This assumes the dummy model (even if trivial) and norm/denorm will change the values.
+        self.assertFalse(
+            np.array_equal(denoised_signal_functional, self.sample_signal),
+            "DDAE functional test with dummy model did not alter the signal as expected."
+        )
+
+    def test_ddae_denoising_zero_signal(self):
+        """Test DDAE with a zero signal to check instance_max_val handling."""
+        zero_signal = np.zeros_like(self.sample_signal)
+        denoised_zero_signal = apply_ddae_denoising(zero_signal, model_path=self.dummy_model_path)
+        self.assertTrue(
+            np.array_equal(denoised_zero_signal, zero_signal),
+            "DDAE should return the original zero signal if instance_max_val is 0."
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
…of `tensorflow.keras`.

This will update Keras import statements across several files to use the `import keras...` convention, aligning with Keras 3 practices as you requested.

Here's what I've done so far:

-   **`src/preprocess.py`**:
    -   I changed `tensorflow.keras.utils.to_categorical` to `keras.utils.to_categorical`.
    -   I changed `tensorflow.keras.models.load_model` to `keras.models.load_model`.

-   **`src/model/autoencoder_model.py`**:
    -   I converted all `tensorflow.keras` imports (layers, models, optimizers)
        to direct `keras` imports.
    -   I removed an unused `import tensorflow as tf`.
    -   I updated model type hints in docstrings to `keras.models.Model`.

-   **`src/train_autoencoder.py`**:
    -   I changed `tensorflow.keras.callbacks` to `keras.callbacks`.
    -   I changed `tf.keras.utils.set_random_seed` to `keras.utils.set_random_seed`.
    -   I added `import keras`.
    -   I retained `import tensorflow as tf` for `tf.random.set_seed` for now,
        and will look into Keras 3's backend seed handling further.

-   **`src/model/callbacks.py`**:
    -   I verified that imports are already `from keras.callbacks...`. No changes
        were needed here.

-   **`src/model/cnn1d_model.py`**:
    -   I removed an unused `import tensorflow as tf`. Keras imports were already
        in the `from keras...` style.

-   **`src/model/cnn2d_model.py`**:
    -   I removed an unused `import tensorflow as tf`. Keras imports were already
        in the `from keras...` style.

I'm continuing to refactor all relevant files. The remaining model files, training/evaluation scripts, and test files will be addressed next.